### PR TITLE
Fix missing quotes

### DIFF
--- a/configure
+++ b/configure
@@ -86,7 +86,7 @@ sudo apt -y install dnsmasq dhcpcd hostapd cron
 sudo bash -c 'cat > /etc/udev/rules.d/70-persistent-net.rules' << EOF
 SUBSYSTEM=="ieee80211", ACTION=="add|change", ATTR{macaddress}=="${MAC_ADDRESS}", KERNEL=="phy0", \
   RUN+="/sbin/iw phy phy0 interface add ap0 type __ap", \
-  RUN+="/bin/ip link set ap0 address ${MAC_ADDRESS}
+  RUN+="/bin/ip link set ap0 address ${MAC_ADDRESS}"
 EOF
 
 # Populate `/etc/dnsmasq.conf`


### PR DESCRIPTION
The udev rule won't work without this.